### PR TITLE
add filter imagesetid by url query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Support metadata and imaging data loading from AWS HealthImaging
 
 
 ## Authors 
-Bill Wallace, Mateus Freira, Radical Imaging, Chris Hafey, Ibrahim Mohamed
+Bill Wallace, Mateus Freira, Radical Imaging, Chris Hafey, Ibrahim Mohamed, Jefferson Tang
 
 ## License 
 MIT

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ohif-aws-healthimaging",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Support reading tree structured metadata",
-  "author": "Bill Wallace, Mateus Freira,Radical Imaging, Ibrahim Mohamed",
+  "author": "Bill Wallace, Mateus Freira,Radical Imaging, Ibrahim Mohamed, Jefferson Tang",
   "keywords": [
     "ohif-extension"
   ],

--- a/src/utils/DicomTreeClient.ts
+++ b/src/utils/DicomTreeClient.ts
@@ -140,7 +140,7 @@ export default class DicomTreeClient extends api.DICOMwebClient {
             if (studies && studies.length) {
                 const [study] = studies;
                 datastoreID = study['00181002']?.Value?.[0] || datastoreID;
-                const imageSetsIds = (study['00200010']?.Value ||[]);
+                const imageSetsIds = search?.get("ImageSetID") ? [ search?.get("ImageSetID") ] : (study['00200010']?.Value ||[]);
                 // Todo do it one by one and go adding to the screen as they arrive
                 const metadataArray = await Promise.all(imageSetsIds.map(async (imageSetId: String) => {
                     const metadataLoaded = await loadMetaDataInternal(datastoreID, imageSetId, this.healthlake);


### PR DESCRIPTION
Addressing issue https://github.com/RadicalImaging/ohif-aws-healthimaging/issues/27

Currently providing `ImageSetID` URL query param will also load scans with different `ImageSetID` but same `StudyInstanceUID`

With this PR:
- Providing `ImageSetID` URL query param will only load the one scan uniquely identified by the imageSetID
- Removing `ImageSetID` query param (and providing `datastore` and `StudyInstanceUIDs`) will load all scans corresponding to provided datastore and StudyInstanceUID - providing identical behaviour as prior

Ran `yarn test` and found that testing metrics were not impacted by PR changes