### PR TITLE
added support for AWS session tokens

### DIFF
--- a/proxy/index.js
+++ b/proxy/index.js
@@ -22,6 +22,7 @@ const headers = {
 const awsCredentials = {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    sessionToken: process.env.AWS_SESSION_TOKEN
 };
 
 const proxy = createServer(async (req, res) => {

--- a/src/imageLoader/awsCredentials.ts
+++ b/src/imageLoader/awsCredentials.ts
@@ -10,6 +10,7 @@ const awsCredentials = (config) => {
   const credentials = {
     secretAccessKey: healthlake?.awsSecretAccessKey || config.awsSecretAccessKey,
     accessKeyId: healthlake?.awsAccessKeyID || config.awsAccessKeyID,
+    sessionToken: healthlake?.awsSessionToken || config.awsSessionToken,
     service: "medical-imaging"
   };
 

--- a/src/utils/DicomTreeClient.ts
+++ b/src/utils/DicomTreeClient.ts
@@ -10,6 +10,7 @@ export type HealthLake = {
     unknown > ;
     awsAccessKeyID: string;
     awsSecretAccessKey: string;
+    awsSessionToken ? : string;
     datastoreID ? : string;
     region ? : string;
     endpoint ? : string;


### PR DESCRIPTION
- allows using short term credentials from AWS STS

aws4 will discard the sessionToken when the parameter is falsey (null, undefined, etc)
