### PR TITLE
add x-amz-security-token header

### DIFF
--- a/src/createDicomWebTreeApi.ts
+++ b/src/createDicomWebTreeApi.ts
@@ -82,6 +82,8 @@ const initializeHealthlakeFetch = (healthlake) => {
           signer.sign().then(({headers}) => {
             xhr.setRequestHeader('x-amz-date', headers.get('x-amz-date'));
             xhr.setRequestHeader('Authorization', headers.get('Authorization'));
+            // 'x-amz-security-token' request header is only required if temporary credentials used. Otherwise will cause authentication error.
+            headers.get('x-amz-security-token') && xhr.setRequestHeader('x-amz-security-token', headers.get('x-amz-security-token'));
             xhr.wasSend(body);
           });
         } else {


### PR DESCRIPTION
Addressing https://github.com/RadicalImaging/ohif-aws-healthimaging/issues/28

PR by @Kevinwochan https://github.com/RadicalImaging/ohif-aws-healthimaging/pull/31 enables optional sessionToken authentication credential. Requests signed using temporary credentials requires an extra request header - `x-amz-security-token`

Tested this PR for both long-term credential (accessKeyId + secretAccessKey) and temporary credential (accessKeyId + secretAccessKey + sessionToken) authentication flows.