### PR TITLE
Fix file format

### DIFF
--- a/src/createDicomWebTreeApi.ts
+++ b/src/createDicomWebTreeApi.ts
@@ -72,7 +72,10 @@ const initializeHealthlakeFetch = (healthlake) => {
       xhr.open('POST', uri, true);
       xhr.wasGetResponseHeader = xhr.getResponseHeader;
       xhr.getResponseHeader = function (key: string) {
-        if (key == 'Content-Type') return 'image/jphc';
+        if (key == 'Content-Type') {
+          let value = this.wasGetResponseHeader(key);
+          return value == "image/j2c" ? 'image/jp2' : "image/jphc";
+        }
         return this.wasGetResponseHeader(key);
       };
 


### PR DESCRIPTION
This change is related to issue #36 . I changed the content type when AWS returns `image/j2c` for frames and it works fine.